### PR TITLE
Question

### DIFF
--- a/app/assets/javascripts/questions.js
+++ b/app/assets/javascripts/questions.js
@@ -21,3 +21,27 @@ $(function () {
     $('#question-answer').fadeToggle();
   });
 });
+
+
+$(function(){
+  // inputのidから情報の取得
+  $('#question_image').on('change', function (e) {
+  // ここから既存の画像のurlの取得
+    var reader = new FileReader();
+    reader.onload = function (e) {
+      $(".question-image").attr('src', e.target.result);
+    }
+  // ここまで
+    reader.readAsDataURL(e.target.files[0]); //取得したurlにアップロード画像のurlを挿入
+  });
+});
+
+$(function(){
+  $('#question_answer_image').on('change', function (e) {
+    var reader = new FileReader();
+    reader.onload = function (e) {
+      $(".answer-image").attr('src', e.target.result);
+    }
+    reader.readAsDataURL(e.target.files[0]);
+  });
+});

--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -25,6 +25,10 @@ div {
   float: left;
 }
 
+.edit {
+  margin-right: 50px;
+}
+
 .question-date {
   float: right;
   line-height: 80px;
@@ -32,13 +36,19 @@ div {
   padding-right: 10px;
 }
 
-.question-content {
+.question-content, .new-question, .edit-question {
   background-color: white;
   padding: 15px;
 }
 
 .question-image {
   width: 100%;
+}
+
+.edit-question {
+  .question-image, .answer-image {
+    width: 75%;
+  }
 }
 
 #hint-1-text, #hint-2-text, #hint-3-text {

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -45,7 +45,6 @@ class QuestionsController < ApplicationController
 
     def question_params
       params.require(:question).permit(:id, :user_id, :sentence, :image, :hint_1, :hint_2, :hint_3,
-                                        :answer, :commentary, :answer_image, :average_rating,
-                                        :remove_image, :remove_answer_image)
+                                        :answer, :commentary, :answer_image, :average_rating)
     end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -23,18 +23,29 @@ class QuestionsController < ApplicationController
   end
 
   def edit
+    @question = Question.find(params[:id])
   end
 
   def update
+    @question = Question.find(params[:id])
+    if @question.update(question_params)
+      redirect_to question_path(@question), notice: "問題を編集しました"
+    else
+      render :edit
+    end
   end
 
   def destroy
+    @question = Question.find(params[:id])
+    @question.destroy
+    redirect_to mypage_questions_path
   end
 
   private
 
     def question_params
       params.require(:question).permit(:id, :user_id, :sentence, :image, :hint_1, :hint_2, :hint_3,
-                                        :answer, :commentary, :answer_image, :average_rating)
+                                        :answer, :commentary, :answer_image, :average_rating,
+                                        :remove_image, :remove_answer_image)
     end
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -8,6 +8,8 @@ header
           li.nav-item
             = link_to "マイページ", mypage_info_path, method: :get, class: "nav-link"
           li.nav-item
+            = link_to "問題を作る", new_question_path, method: :get, class: "nav-link"
+          li.nav-item
             = link_to "問題を探す", questions_path, method: :get, class: "nav-link"
           li.nav-item
             = link_to "ユーザを探す", users_path, method: :get, class: "nav-link"

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -1,0 +1,37 @@
+h3 問題編集
+= form_with model: @question, local: true do |f|
+  div.edit-question
+    div.field
+      = f.label :id, "問題No"
+      = f.number_field :id
+    div.field
+      = f.label :sentence, "問題"
+      = f.hidden_field :sentence, id: "question_sentence"
+      trix-editor input="question_sentence"
+    div.field
+      = f.label :image, "問題画像"
+      = attachment_image_tag @question, :image, class: "question-image"
+      = f.attachment_field :image
+    div.field
+      = f.label :hint_1, "ヒント１"
+      = f.text_field :hint_1
+    div.field
+      = f.label :hint_2, "ヒント２"
+      = f.text_field :hint_2
+    div.field
+      = f.label :hint_3, "ヒント３"
+      = f.text_field :hint_3
+    div.field
+      = f.label :answer, "正解"
+      = f.text_field :answer
+    div.field
+      = f.label :commentary, "解説"
+      = f.hidden_field :commentary, id: "question_commentary"
+      trix-editor input="question_commentary"
+    div.field
+      = f.label :answer_image, "解説画像"
+      = attachment_image_tag @question, :answer_image, class: "answer-image"
+      = f.attachment_field :answer_image
+
+    = f.submit "編集する", class: "btn btn-lg btn-success edit"
+    = link_to "戻る", question_path(@question), class: "btn btn-lg btn-danger"

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -36,7 +36,7 @@ div.col-xs-9
     div.question-answer
       button#show-answer.btn.btn-danger 正解を見る
       div#question-answer
-        = @question.answer
+        strong 正解： #{@question.answer}
         h4
           strong 解説
         = sanitize @question.commentary


### PR DESCRIPTION
- Questionのedit, update, destroy機能を実装
- 問題編集画面で画像のプレビュー機能を実装
  - 事前に画像がアップロードされている時のみプレビュー画像が表示される状態。原因は現状不明
- ログイン時のヘッダーに問題作成のリンクを追加
