### PR TITLE
Fix question_model association

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,6 @@
 class Question < ApplicationRecord
   belongs_to :user
-  has_many :ratings
+  has_many :ratings, dependent: :delete_all
   attachment :image
   attachment :answer_image
 


### PR DESCRIPTION
問題を削除した時、ratingのコールバックが実行されエラーが出た為、questionモデルとratingモデルの関連付けをdependent: :destroyにしようとしていたが、dependent: :delete_allに変更
delete_allではコールバックは実行されないため、評価コメントが紐付いている問題でも正常に削除できるようになりました