### PR TITLE
Fix

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -47,7 +47,7 @@ class QuestionsController < ApplicationController
   private
 
     def question_params
-      params.require(:question).permit(:id, :user_id, :sentence, :image, :hint_1, :hint_2, :hint_3,
+      params.require(:question).permit(:id, :question_number, :user_id, :sentence, :image, :hint_1, :hint_2, :hint_3,
                                         :answer, :commentary, :answer_image, :average_rating)
     end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -47,7 +47,7 @@ class QuestionsController < ApplicationController
   private
 
     def question_params
-      params.require(:question).permit(:id, :question_number, :user_id, :sentence, :image, :hint_1, :hint_2, :hint_3,
+      params.require(:question).permit(:number, :user_id, :sentence, :image, :hint_1, :hint_2, :hint_3,
                                         :answer, :commentary, :answer_image, :average_rating)
     end
 end

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -2,8 +2,8 @@ h3 問題編集
 = form_with model: @question, local: true do |f|
   div.edit-question
     div.field
-      = f.label :question_number, "問題No"
-      = f.number_field :question_number
+      = f.label :number, "問題No"
+      = f.number_field :number
     div.field
       = f.label :sentence, "問題"
       = f.hidden_field :sentence, id: "question_sentence"

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -2,8 +2,8 @@ h3 問題編集
 = form_with model: @question, local: true do |f|
   div.edit-question
     div.field
-      = f.label :id, "問題No"
-      = f.number_field :id
+      = f.label :question_number, "問題No"
+      = f.number_field :question_number
     div.field
       = f.label :sentence, "問題"
       = f.hidden_field :sentence, id: "question_sentence"

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -4,7 +4,7 @@ div.col-xs-12
     div.question-bar
       = link_to question_path(question)
         div.question-number
-          h1 No.#{question.question_number}
+          h1 No.#{question.number}
         div.question-user
           div.question-user-image
             = attachment_image_tag question.user, :image, :fill, 60, 60, fallback: "no_image.png",size: "60x60", class: "img-circle pull-left profile-thumb"

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -4,7 +4,7 @@ div.col-xs-12
     div.question-bar
       = link_to question_path(question)
         div.question-number
-          h1 No.#{question.id}
+          h1 No.#{question.question_number}
         div.question-user
           div.question-user-image
             = attachment_image_tag question.user, :image, :fill, 60, 60, fallback: "no_image.png",size: "60x60", class: "img-circle pull-left profile-thumb"

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -2,8 +2,8 @@ h3 問題作成
 = form_with model: @question, local: true do |f|
   div.new-question
     div.field
-      = f.label :id, "問題No"
-      = f.number_field :id
+      = f.label :question_number, "問題No"
+      = f.number_field :question_number
     div.field
       = f.label :sentence, "問題"
       = f.hidden_field :sentence, id: "question_sentence"

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -2,8 +2,8 @@ h3 問題作成
 = form_with model: @question, local: true do |f|
   div.new-question
     div.field
-      = f.label :question_number, "問題No"
-      = f.number_field :question_number
+      = f.label :number, "問題No"
+      = f.number_field :number
     div.field
       = f.label :sentence, "問題"
       = f.hidden_field :sentence, id: "question_sentence"

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -2,7 +2,7 @@ div#rating-modal
 div.col-xs-12
   div.row.question-info
     div.question-number
-      h1 No.#{@question.id}
+      h1 No.#{@question.question_number}
     div.question-user
       = link_to user_path(@question.user)
         div.question-user-image

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -2,7 +2,7 @@ div#rating-modal
 div.col-xs-12
   div.row.question-info
     div.question-number
-      h1 No.#{@question.question_number}
+      h1 No.#{@question.number}
     div.question-user
       = link_to user_path(@question.user)
         div.question-user-image

--- a/db/migrate/20200929063007_add_column_to_question.rb
+++ b/db/migrate/20200929063007_add_column_to_question.rb
@@ -1,0 +1,6 @@
+class AddColumnToQuestion < ActiveRecord::Migration[5.2]
+  def change
+    add_column :questions, :question_number, :integer
+    add_index :questions, :question_number, unique: true
+  end
+end

--- a/db/migrate/20200929063007_add_column_to_question.rb
+++ b/db/migrate/20200929063007_add_column_to_question.rb
@@ -1,6 +1,6 @@
 class AddColumnToQuestion < ActiveRecord::Migration[5.2]
   def change
-    add_column :questions, :question_number, :integer
-    add_index :questions, :question_number, unique: true
+    add_column :questions, :number, :integer
+    add_index :questions, :number, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,8 +35,8 @@ ActiveRecord::Schema.define(version: 2020_09_29_063007) do
     t.float "average_rating", default: 0.0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "question_number"
-    t.index ["question_number"], name: "index_questions_on_question_number", unique: true
+    t.integer "number"
+    t.index ["number"], name: "index_questions_on_number", unique: true
     t.index ["user_id"], name: "index_questions_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_27_094017) do
+ActiveRecord::Schema.define(version: 2020_09_29_063007) do
 
   create_table "favorites", force: :cascade do |t|
     t.integer "user_id"
@@ -35,6 +35,8 @@ ActiveRecord::Schema.define(version: 2020_09_27_094017) do
     t.float "average_rating", default: 0.0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "question_number"
+    t.index ["question_number"], name: "index_questions_on_question_number", unique: true
     t.index ["user_id"], name: "index_questions_on_user_id"
   end
 


### PR DESCRIPTION
- Questionモデルにnumberカラムを追加
  - id = 問題No.としていると、問題No.を編集した時に紐付いている評価コメントのQuestionモデルへの外部キーの参照先がなくなってしまうのでエラーが発生する<br>idは不変の値にし、新たに問題No.用のカラムを設けることでこの問題を解消した。