### PR TITLE
Add oauth login_failure_message

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -13,6 +13,7 @@ ja:
     omniauth_callbacks:
       user:
         success: "githubアカウントでログインしました。"
+        failure: "githubアカウントでのログインに失敗しました。"
     failure:
       unauthenticated: 'ログインしてください。'
 #      unauthenticated: 'You need to sign in or sign up before continuing.'


### PR DESCRIPTION
githubアカウントでログインに失敗したときのメッセージを追加